### PR TITLE
Obtain deps at startup, not during docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,8 @@
 FROM ubuntu:latest
 
-MAINTAINER Ben Smith (benjsmi@us.ibm.com)
+MAINTAINER Ozzy (ozzy@ca.ibm.com)
 
-ADD https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@game-on.org:8443/jdk-8u66-linux-x64.gz /opt/
-ADD https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@game-on.org:8443/logstash-mtlumberjack.tgz /opt/
-
-RUN cd /opt ; tar xzf jdk-8u66-linux-x64.gz ; tar xf logstash-mtlumberjack.tgz ; \
-	rm jdk-8u66-linux-x64.gz ; rm logstash-mtlumberjack.tgz ; apt-get update ; apt-get install -y wget
+RUN apt-get update && apt-get install -y wget
 
 COPY ./logstash.conf /opt/logstash/bin/logstash.conf
 COPY ./patterns/nginx /opt/logstash/patterns/

--- a/idsBuild.sh
+++ b/idsBuild.sh
@@ -24,6 +24,7 @@ echo Setting configuration to match with your Bluemix Org and Space information 
 ./client-config.sh $BLUEMIX_USER $BLUEMIX_PASSWORD $BLUEMIX_ORG $BLUEMIX_SPACE
 
 echo Building the docker image...
+sed -i s/PLACEHOLDER_DOWNLOAD_PASSWORD/$DOWNLOAD_PASSWORD/g ./startup.sh
 sed -i s/PLACEHOLDER_DOWNLOAD_PASSWORD/$DOWNLOAD_PASSWORD/g ./Dockerfile
 ./docker/docker build -t gameon-logstash .
 ./docker/docker stop -t 0 gameon-logstash

--- a/startup.sh
+++ b/startup.sh
@@ -1,4 +1,11 @@
-#!/bin/bash 
+#!/bin/bash
+
+echo Obtaining dependencies.
+export HOST=$(etcdctl get /proxy/docker-host)
+mkdir -p /opt
+wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/jdk-8u66-linux-x64.gz /tmp/jdk.gz && tar xvzf /tmp/jdk.gz -C /opt && rm /tmp/jdk.gz
+wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/logstash-mtlumberjack.tgz /tmp/logstash.gz && tar xvzf /tmp/logstash.gz -C /opt && rm /tmp/logstash.gz
+
 echo Setting up etcd...
 wget https://github.com/coreos/etcd/releases/download/v2.2.2/etcd-v2.2.2-linux-amd64.tar.gz -q
 tar xzf etcd-v2.2.2-linux-amd64.tar.gz etcd-v2.2.2-linux-amd64/etcdctl --strip-components=1


### PR DESCRIPTION
Certs have expired in our deps container, so we've made it only listen
to the internal docker network, and then changed startup.sh to pull the
deps rather than Dockerfile.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-logstash/1)
<!-- Reviewable:end -->
