### PR TITLE
Attempt to use etcd before etcd installed denied.

### DIFF
--- a/startup.sh
+++ b/startup.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-echo Obtaining dependencies.
-export HOST=$(etcdctl get /proxy/docker-host)
-mkdir -p /opt
-wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/jdk-8u66-linux-x64.gz /tmp/jdk.gz && tar xvzf /tmp/jdk.gz -C /opt && rm /tmp/jdk.gz
-wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/logstash-mtlumberjack.tgz /tmp/logstash.gz && tar xvzf /tmp/logstash.gz -C /opt && rm /tmp/logstash.gz
-
 echo Setting up etcd...
 wget https://github.com/coreos/etcd/releases/download/v2.2.2/etcd-v2.2.2-linux-amd64.tar.gz -q
 tar xzf etcd-v2.2.2-linux-amd64.tar.gz etcd-v2.2.2-linux-amd64/etcdctl --strip-components=1
 rm etcd-v2.2.2-linux-amd64.tar.gz
 mv etcdctl /usr/local/bin/etcdctl
+
+echo Obtaining dependencies.
+export HOST=$(etcdctl get /proxy/docker-host)
+mkdir -p /opt
+wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/jdk-8u66-linux-x64.gz /tmp/jdk.gz && tar xvzf /tmp/jdk.gz -C /opt && rm /tmp/jdk.gz
+wget --no-check-certificate https://admin:PLACEHOLDER_DOWNLOAD_PASSWORD@${HOST}:8982/logstash-mtlumberjack.tgz /tmp/logstash.gz && tar xvzf /tmp/logstash.gz -C /opt && rm /tmp/logstash.gz
 
 echo Starting logstash...
 etcdctl get /logstash/cert > /opt/logstash-forwarder.crt


### PR DESCRIPTION
Apparently shell scripts are not allowed to violate the concepts of
linear time. Resequence the usage of etcdctl to be _After_ the
installation of same.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-logstash/2)
<!-- Reviewable:end -->
